### PR TITLE
extend callback argument

### DIFF
--- a/lib/GridfsStorage.js
+++ b/lib/GridfsStorage.js
@@ -53,7 +53,7 @@ function streamFileToGridFS(req, file, cb) {
     file.stream.pipe(writestream);
     writestream.on('close', function (file) {
         console.log('saved', file);
-        cb();
+        cb(null, { gridfsEntry: file });
     });
 }
 GridFSStorage.prototype._handleFile = function _handleFile(req, file, cb) {


### PR DESCRIPTION
Hi Ismael. I extend your callback so that it contains the entry from the mongo database. So the user have access to the file._id and some special properties.

best regards

René